### PR TITLE
Add Nextcloud calendar integration service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Server configuration
+PORT=3001
+SERVER_NAME=nextcloud-calendar-server
+SERVER_VERSION=1.0.0
+NODE_ENV=development
+
+# Nextcloud configuration
+NEXTCLOUD_BASE_URL=https://nextcloud.jonathanflatt.org
+NEXTCLOUD_USERNAME=your-username
+NEXTCLOUD_APP_TOKEN=your-app-token

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# MCP Nextcloud Calendar
+
+A Model Context Protocol (MCP) server for Nextcloud Calendar integration.
+
+## Features
+
+- Fetch calendars from Nextcloud
+- ADHD-friendly organization features
+- MCP protocol support
+
+## Setup
+
+### Installation
+
+1. Clone the repository
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+### Configuration
+
+This project uses environment variables for configuration. You can set them up in two ways:
+
+1. Create a `.env` file in the project root (copy from `.env.example`):
+
+```bash
+cp .env.example .env
+```
+
+2. Edit the `.env` file with your Nextcloud credentials:
+
+```
+# Server configuration
+PORT=3001
+SERVER_NAME=nextcloud-calendar-server
+SERVER_VERSION=1.0.0
+NODE_ENV=development
+
+# Nextcloud configuration
+NEXTCLOUD_BASE_URL=https://your-nextcloud-server.com
+NEXTCLOUD_USERNAME=your-username
+NEXTCLOUD_APP_TOKEN=your-app-token
+```
+
+### Getting a Nextcloud App Token
+
+1. Log in to your Nextcloud instance
+2. Go to Settings → Security → App Passwords
+3. Create a new app password with a name like "MCP Calendar"
+4. Copy the generated token to your `.env` file
+
+## Development
+
+```bash
+# Build the project
+npm run build
+
+# Run in development mode
+npm run dev
+
+# Run tests
+npm run test
+
+# Run linting
+npm run lint
+
+# Format code
+npm run format
+```
+
+## API Endpoints
+
+- `GET /health` - Health check endpoint
+- `GET /api/calendars` - List all calendars
+
+## License
+
+ISC

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "@types/express": "^5.0.1",
         "@types/node": "^22.14.1",
         "axios": "^1.8.4",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
+        "xml2js": "^0.6.2",
         "zod": "^3.24.2"
       },
       "bin": {
@@ -23,6 +25,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
         "@typescript-eslint/parser": "^8.30.1",
         "eslint": "^9.24.0",
@@ -33,6 +36,9 @@
         "lint-staged": "^15.5.1",
         "prettier": "^3.5.3",
         "ts-jest": "^29.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1560,6 +1566,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -2583,6 +2598,17 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -5906,6 +5932,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -6673,6 +6704,26 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,16 @@
     "@types/express": "^5.0.1",
     "@types/node": "^22.14.1",
     "axios": "^1.8.4",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
+    "xml2js": "^0.6.2",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "@typescript-eslint/parser": "^8.30.1",
     "eslint": "^9.24.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,8 +1,19 @@
+import { config } from 'dotenv';
+
+// Load environment variables from .env file
+config();
+
 export interface ServerConfig {
   port: number;
   serverName: string;
   serverVersion: string;
   environment: string;
+}
+
+export interface NextcloudConfig {
+  baseUrl: string;
+  username: string;
+  appToken: string;
 }
 
 const defaultConfig: ServerConfig = {
@@ -12,11 +23,18 @@ const defaultConfig: ServerConfig = {
   environment: 'development',
 };
 
-export function loadConfig(): ServerConfig {
+export function loadConfig(): { server: ServerConfig; nextcloud: NextcloudConfig } {
   return {
-    port: parseInt(process.env.PORT || String(defaultConfig.port)),
-    serverName: process.env.SERVER_NAME || defaultConfig.serverName,
-    serverVersion: process.env.SERVER_VERSION || defaultConfig.serverVersion,
-    environment: process.env.NODE_ENV || defaultConfig.environment,
+    server: {
+      port: parseInt(process.env.PORT || String(defaultConfig.port)),
+      serverName: process.env.SERVER_NAME || defaultConfig.serverName,
+      serverVersion: process.env.SERVER_VERSION || defaultConfig.serverVersion,
+      environment: process.env.NODE_ENV || defaultConfig.environment,
+    },
+    nextcloud: {
+      baseUrl: process.env.NEXTCLOUD_BASE_URL || '',
+      username: process.env.NEXTCLOUD_USERNAME || '',
+      appToken: process.env.NEXTCLOUD_APP_TOKEN || '',
+    }
   };
 }

--- a/src/handlers/calendars.ts
+++ b/src/handlers/calendars.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { CalendarService } from '../services/index.js';
+
+export function getCalendarsHandler(calendarService: CalendarService | null) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!calendarService) {
+      res.status(503).json({ error: 'Calendar service not available' });
+      return;
+    }
+
+    calendarService.getCalendars()
+      .then(calendars => {
+        res.status(200).json({ calendars });
+      })
+      .catch(error => {
+        console.error('Error getting calendars:', error);
+        res.status(500).json({ error: `Failed to get calendars: ${(error as Error).message}` });
+      });
+  };
+}

--- a/src/handlers/sse.ts
+++ b/src/handlers/sse.ts
@@ -33,6 +33,6 @@ export function setupSseHandlers(server: McpServer) {
   return {
     sseHandler,
     messageHandler,
-    transports
+    transports,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,63 @@
 #!/usr/bin/env node
-import express from 'express';
+import * as express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { loadConfig } from './config/config.js';
 import { healthHandler } from './handlers/health.js';
 import { setupSseHandlers } from './handlers/sse.js';
+import { getCalendarsHandler } from './handlers/calendars.js';
+import { CalendarService } from './services/index.js';
 
 // Load configuration
 const config = loadConfig();
+const { server: serverConfig, nextcloud: nextcloudConfig } = config;
+
+// Initialize services
+let calendarService: CalendarService | null = null;
+try {
+  if (nextcloudConfig.baseUrl && nextcloudConfig.username && nextcloudConfig.appToken) {
+    calendarService = new CalendarService(nextcloudConfig);
+    console.log('Calendar service initialized successfully');
+  } else {
+    console.warn('Nextcloud configuration incomplete - Calendar service not initialized');
+  }
+} catch (error) {
+  console.error('Failed to initialize calendar service:', error);
+}
 
 // Create MCP server
 const server = new McpServer({
-  name: config.serverName,
-  version: config.serverVersion,
+  name: serverConfig.serverName,
+  version: serverConfig.serverVersion,
 });
 
 // Setup Express app
-const app = express();
-app.use(express.json());
+const app = express.default();
+app.use(express.default.json());
 
-// Setup SSE handlers
+// Setup handlers
 const { sseHandler, messageHandler } = setupSseHandlers(server);
 
 // Configure routes
-app.get('/health', healthHandler(config));
+app.get('/health', healthHandler(serverConfig));
 app.get('/sse', sseHandler);
 app.post('/messages', messageHandler);
+
+// Calendar routes
+app.get('/api/calendars', getCalendarsHandler(calendarService));
 
 // Graceful shutdown handling
 const gracefulShutdown = () => {
   console.log('Shutting down gracefully...');
-  server.close().then(() => {
-    console.log('Server closed');
-    process.exit(0);
-  }).catch(err => {
-    console.error('Error during shutdown:', err);
-    process.exit(1);
-  });
+  server
+    .close()
+    .then(() => {
+      console.log('Server closed');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Error during shutdown:', err);
+      process.exit(1);
+    });
 };
 
 // Handle termination signals
@@ -43,6 +65,8 @@ process.on('SIGTERM', gracefulShutdown);
 process.on('SIGINT', gracefulShutdown);
 
 // Start the server
-app.listen(config.port, () => {
-  console.log(`Nextcloud Calendar MCP server running on port ${config.port} in ${config.environment} mode`);
+app.listen(serverConfig.port, () => {
+  console.log(
+    `Nextcloud Calendar MCP server running on port ${serverConfig.port} in ${serverConfig.environment} mode`,
+  );
 });

--- a/src/services/calendar.service.ts
+++ b/src/services/calendar.service.ts
@@ -1,0 +1,270 @@
+import axios from 'axios';
+import { parseStringPromise } from 'xml2js';
+import { NextcloudConfig } from '../config/config.js';
+import { Calendar, CalendarUtils } from '../models/index.js';
+
+export class CalendarService {
+  private config: NextcloudConfig;
+  private authHeader: string;
+  private baseUrl: string;
+  private caldavUrl: string;
+
+  constructor(config: NextcloudConfig) {
+    this.config = config;
+    
+    if (!this.config.baseUrl || !this.config.username || !this.config.appToken) {
+      throw new Error('Nextcloud configuration is incomplete');
+    }
+    
+    // Remove trailing slash if present
+    this.baseUrl = this.config.baseUrl.replace(/\/$/, '');
+    
+    // Create the CalDAV URL for the user
+    this.caldavUrl = `${this.baseUrl}/remote.php/dav/calendars/${this.config.username}/`;
+    
+    console.log('Initialized CalendarService with:');
+    console.log('  Base URL:', this.baseUrl);
+    console.log('  CalDAV URL:', this.caldavUrl);
+    console.log('  Username:', this.config.username);
+    
+    // Create Basic Auth header
+    // Use global Buffer (available in Node.js)
+    // eslint-disable-next-line no-undef
+    const auth = Buffer.from(`${config.username}:${config.appToken}`).toString('base64');
+    this.authHeader = `Basic ${auth}`;
+  }
+
+  /**
+   * Get a list of all calendars for the user
+   * @returns Promise<Calendar[]> List of calendars
+   */
+  async getCalendars(): Promise<Calendar[]> {
+    try {
+      // Make request to Nextcloud CalDAV endpoint with PROPFIND
+      const response = await axios({
+        method: 'PROPFIND',
+        url: this.caldavUrl,
+        headers: {
+          'Authorization': this.authHeader,
+          'Depth': '1',
+          'Content-Type': 'application/xml; charset=utf-8',
+        },
+        data: `<?xml version="1.0" encoding="utf-8" ?>
+              <d:propfind xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav"
+                  xmlns:cs="http://calendarserver.org/ns/" xmlns:oc="http://owncloud.org/ns">
+                <d:prop>
+                  <d:resourcetype />
+                  <d:displayname />
+                  <cal:supported-calendar-component-set />
+                  <cs:getctag />
+                  <oc:calendar-enabled />
+                  <d:sync-token />
+                  <oc:owner-principal />
+                  <d:current-user-privilege-set />
+                  <oc:invite />
+                  <oc:calendar-order />
+                  <d:color />
+                </d:prop>
+              </d:propfind>`
+      });
+      
+      // Parse XML response
+      const xmlData = await parseStringPromise(response.data, { explicitArray: false });
+      
+      // Extract calendar information
+      const calendars: Calendar[] = [];
+      
+      if (xmlData && xmlData['d:multistatus'] && xmlData['d:multistatus']['d:response']) {
+        const responses = Array.isArray(xmlData['d:multistatus']['d:response']) 
+          ? xmlData['d:multistatus']['d:response'] 
+          : [xmlData['d:multistatus']['d:response']];
+          
+        for (const item of responses) {
+          // Skip the parent directory response
+          if (item['d:href'] === this.caldavUrl.substring(this.baseUrl.length) || 
+              !item['d:propstat']) {
+            continue;
+          }
+          
+          // Find successful propstat
+          const propstat = Array.isArray(item['d:propstat'])
+            ? item['d:propstat'].find((ps: { 'd:status'?: string }) => ps['d:status'] === 'HTTP/1.1 200 OK')
+            : item['d:propstat'];
+            
+          if (propstat && propstat['d:prop']) {
+            const prop = propstat['d:prop'];
+            
+            // Only process items that are calendars
+            if (prop['d:resourcetype'] && 
+                (prop['d:resourcetype']['cal:calendar'] || 
+                 (typeof prop['d:resourcetype'] === 'object' && 
+                  Object.keys(prop['d:resourcetype']).some(key => key.includes('calendar'))))) {
+              
+              const calendarId = item['d:href'].split('/').filter(Boolean).pop();
+              
+              // For testing, always consider calendars enabled since Nextcloud doesn't always expose this property
+              // Skip disabled calendars if the property exists
+              if (prop['oc:calendar-enabled'] === '0') {
+                continue;
+              }
+              
+              // Extract permission information
+              const privileges = this.parsePrivilegeSet(prop['d:current-user-privilege-set']);
+              
+              // Determine if shared
+              const isShared = !!prop['oc:invite'];
+              
+              // Extract owner information
+              let owner = this.config.username;
+              if (prop['oc:owner-principal']) {
+                const ownerMatch = prop['oc:owner-principal'].match(/principal:principals\/users\/([^/]+)/);
+                if (ownerMatch && ownerMatch[1]) {
+                  owner = ownerMatch[1];
+                }
+              }
+              
+              // Extract color (strip quotes if present)
+              let color = prop['d:color'] || prop['x1:calendar-color'] || '#0082c9';
+              if (typeof color === 'string' && color.startsWith('"') && color.endsWith('"')) {
+                color = color.substring(1, color.length - 1);
+              }
+              
+              // Create calendar object
+              const calendar = CalendarUtils.toCalendar({
+                id: calendarId,
+                displayName: prop['d:displayname'] || calendarId,
+                color: color,
+                owner: owner,
+                isDefault: calendarId === 'personal', // Personal is usually the default calendar
+                isShared: isShared,
+                isReadOnly: !privileges.canWrite,
+                permissions: {
+                  canRead: privileges.canRead,
+                  canWrite: privileges.canWrite,
+                  canShare: privileges.canShare,
+                  canDelete: privileges.canDelete
+                },
+                url: `${this.baseUrl}${item['d:href']}`,
+                // For ADHD-friendly organization
+                category: null,
+                focusPriority: null,
+                metadata: null
+              });
+              
+              calendars.push(calendar);
+            }
+          }
+        }
+      }
+      
+      return calendars;
+    } catch (error) {
+      console.error('Error fetching calendars:', error);
+      throw new Error(`Failed to fetch calendars: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Create a new calendar
+   * @param newCalendar Calendar object with properties for the new calendar
+   * @returns Promise<Calendar> The created calendar with server-assigned properties
+   * 
+   * TODO: Implementation needed (GitHub issue #4) with the following:
+   * - Create calendar using MKCALENDAR WebDAV method
+   * - Set calendar properties like displayName, color
+   * - Support ADHD-friendly organization features
+   * - Handle authorization errors
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createCalendar(newCalendar: Omit<Calendar, 'id' | 'url'>): Promise<Calendar> {
+    throw new Error('Not implemented - see GitHub issue #4');
+  }
+
+  /**
+   * Update an existing calendar
+   * @param calendarId ID of the calendar to update
+   * @param updates Calendar object with updated properties
+   * @returns Promise<Calendar> The updated calendar
+   * 
+   * TODO: Implementation needed (GitHub issue #4) with the following:
+   * - Update calendar properties using PROPPATCH WebDAV method
+   * - Support updating displayName, color, and ADHD organization properties
+   * - Handle missing calendar and permission errors
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async updateCalendar(calendarId: string, updates: Partial<Calendar>): Promise<Calendar> {
+    throw new Error('Not implemented - see GitHub issue #4');
+  }
+
+  /**
+   * Delete a calendar
+   * @param calendarId ID of the calendar to delete
+   * @returns Promise<boolean> True if calendar was deleted successfully
+   * 
+   * TODO: Implementation needed (GitHub issue #4) with the following:
+   * - Delete calendar using DELETE WebDAV method
+   * - Proper error handling for permission issues
+   * - Check if calendar exists before attempting deletion
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async deleteCalendar(calendarId: string): Promise<boolean> {
+    throw new Error('Not implemented - see GitHub issue #4');
+  }
+
+  /**
+   * Helper function to parse WebDAV privilege set into permission object
+   */
+  private parsePrivilegeSet(privilegeSet: Record<string, unknown> | null): { 
+    canRead: boolean; 
+    canWrite: boolean; 
+    canShare: boolean; 
+    canDelete: boolean; 
+  } {
+    const permissions = {
+      canRead: false,
+      canWrite: false,
+      canShare: false,
+      canDelete: false
+    };
+    
+    // If no privilege set provided, default to read-only access
+    if (!privilegeSet) {
+      permissions.canRead = true;
+      return permissions;
+    }
+    
+    // If no privileges found, assume read access
+    if (!privilegeSet['d:privilege']) {
+      permissions.canRead = true;
+      return permissions;
+    }
+    
+    const privileges = Array.isArray(privilegeSet['d:privilege']) 
+      ? privilegeSet['d:privilege'] 
+      : [privilegeSet['d:privilege']];
+      
+    // For Nextcloud, assume we have read access if we can see the calendar at all
+    permissions.canRead = true;
+    
+    for (const privilege of privileges) {
+      // Write permissions
+      if (privilege['d:write'] || 
+          privilege['d:write-content'] || 
+          privilege['d:write-properties']) {
+        permissions.canWrite = true;
+      }
+      
+      // Share permission (Nextcloud specific)
+      if (privilege['d:share'] || privilege['oc:share']) {
+        permissions.canShare = true;
+      }
+      
+      // Delete permission
+      if (privilege['d:unbind'] || privilege['d:write']) {
+        permissions.canDelete = true;
+      }
+    }
+    
+    return permissions;
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Export all services
+ */
+
+export { CalendarService } from './calendar.service.js';


### PR DESCRIPTION
Adds basic Nextcloud calendar integration with CalDAV support.

## Summary
- Implements basic auth with username/app-token authentication
- Adds CalDAV PROPFIND request support for listing calendars
- Parses XML responses using xml2js
- Adds environment variable configuration with dotenv
- Adds proper error handling and type safety
- Includes documentation for setup and usage
- Adds stubs for future calendar CRUD operations

## Test plan
1. Create a .env file based on .env.example with Nextcloud credentials
2. Run the server with 'npm run dev'
3. Test the /api/calendars endpoint to verify calendar list is returned