### PR TITLE
Add EventService for Nextcloud calendar events CRUD operations

### DIFF
--- a/src/services/calendar/event-service.ts
+++ b/src/services/calendar/event-service.ts
@@ -4,7 +4,7 @@
 import { NextcloudConfig } from '../../config/config.js';
 import { Event } from '../../models/index.js';
 import { createLogger } from '../logger.js';
-import { CalendarHttpClient } from './http-client.js';
+import { CalendarHttpClient, CalDavError } from './http-client.js';
 import * as XmlUtils from './xml-utils.js';
 import * as iCalUtils from './ical-utils.js';
 import crypto from 'crypto';
@@ -442,8 +442,8 @@ export class EventService {
     } catch (error) {
       this.logger.error(`Error updating event ${eventId} in calendar ${calendarId}:`, error);
 
-      // Special handling for precondition failed errors
-      if ((error as Error).message.includes('Precondition Failed')) {
+      // Check for optimistic concurrency failures using the CalDavError type
+      if (error instanceof CalDavError && error.isOptimisticConcurrencyFailure) {
         throw new Error(
           `The event was modified by another user. Please refresh the event data and try again.`,
         );

--- a/src/services/calendar/event-service.ts
+++ b/src/services/calendar/event-service.ts
@@ -1,0 +1,491 @@
+/**
+ * Service for handling Nextcloud calendar events via CalDAV
+ */
+import axios from 'axios';
+import { NextcloudConfig } from '../../config/config.js';
+import { Event } from '../../models/index.js';
+import { createLogger } from '../logger.js';
+import { CalendarHttpClient } from './http-client.js';
+import * as XmlUtils from './xml-utils.js';
+import * as iCalUtils from './ical-utils.js';
+import crypto from 'crypto';
+// For handling the Buffer in Node.js environment
+import { Buffer } from 'buffer';
+
+export class EventService {
+  private config: NextcloudConfig;
+  private httpClient: CalendarHttpClient;
+  private logger = createLogger('EventService');
+
+  constructor(config: NextcloudConfig) {
+    this.config = config;
+
+    if (!this.config.baseUrl || !this.config.username || !this.config.appToken) {
+      throw new Error('Nextcloud configuration is incomplete');
+    }
+
+    // Remove trailing slash if present
+    const baseUrl = this.config.baseUrl.replace(/\/$/, '');
+
+    // Initialize HTTP client
+    this.httpClient = new CalendarHttpClient(baseUrl, this.config.username, this.config.appToken);
+
+    // Log initialization without sensitive details
+    this.logger.info('EventService initialized successfully', {
+      baseUrl: baseUrl,
+      username: this.config.username,
+    });
+  }
+
+  /**
+   * Get events from a calendar with optional filtering
+   * @param calendarId ID of the calendar to get events from
+   * @param options Optional filtering parameters
+   * @returns Promise<Event[]> List of events
+   */
+  async getEvents(
+    calendarId: string,
+    options?: {
+      start?: Date;
+      end?: Date;
+      limit?: number;
+      expandRecurring?: boolean;
+      priorityMinimum?: number;
+      adhdCategory?: string;
+      tags?: string[];
+    },
+  ): Promise<Event[]> {
+    this.logger.debug(`Fetching events for calendar ${calendarId}`, options);
+
+    try {
+      // Validate calendar ID
+      if (!calendarId) {
+        throw new Error('Calendar ID is required');
+      }
+
+      // Build the REPORT request for calendar events
+      const reportXml = XmlUtils.buildEventsReportRequest(options?.start, options?.end);
+
+      // Send the REPORT request
+      const reportResponse = await this.httpClient.calendarReport(calendarId, reportXml);
+
+      // Parse the XML response
+      const xmlData = await XmlUtils.parseXmlResponse(reportResponse);
+
+      // Extract events from the response
+      const events: Event[] = [];
+      const multistatus = XmlUtils.getMultistatus(xmlData);
+
+      if (multistatus) {
+        const responses = XmlUtils.getResponses(multistatus);
+
+        for (const response of responses) {
+          try {
+            // Get the href (event URL)
+            const href = response['d:href'];
+
+            if (!href) {
+              continue;
+            }
+
+            // Find successful propstat
+            const propstat = Array.isArray(response['d:propstat'])
+              ? response['d:propstat'].find(
+                  (ps: { 'd:status'?: string }) => ps['d:status'] === 'HTTP/1.1 200 OK',
+                )
+              : response['d:propstat'];
+
+            if (!propstat || !propstat['d:prop']) {
+              continue;
+            }
+
+            const prop = propstat['d:prop'];
+
+            // Get the calendar data (iCalendar format)
+            const calendarData = prop['c:calendar-data'] || prop['calendar-data'];
+
+            if (!calendarData) {
+              continue;
+            }
+
+            // Parse the iCalendar data
+            const parsedEvents = iCalUtils.parseICalEvents(calendarData.toString(), calendarId);
+
+            // Add to our list of events
+            events.push(...parsedEvents);
+          } catch (parseError) {
+            this.logger.warn('Error parsing event response:', parseError);
+          }
+        }
+      }
+
+      // Handle recurring events expansion if requested
+      if (options?.expandRecurring && events.some((event) => event.recurrenceRule)) {
+        this.logger.debug('Expanding recurring events');
+
+        // TODO: Implement recurring events expansion when needed
+        // This will involve another REPORT request with the calendar-multiget method
+      }
+
+      // Apply client-side filtering
+      let filteredEvents = events;
+
+      // Filter by ADHD category if specified
+      if (options?.adhdCategory) {
+        filteredEvents = filteredEvents.filter(
+          (event) => event.adhdCategory === options.adhdCategory,
+        );
+      }
+
+      // Filter by minimum priority if specified
+      if (options?.priorityMinimum !== undefined) {
+        filteredEvents = filteredEvents.filter(
+          (event) =>
+            event.focusPriority !== undefined &&
+            event.focusPriority >= (options.priorityMinimum as number),
+        );
+      }
+
+      // Filter by tags if specified
+      if (options?.tags && options.tags.length > 0) {
+        filteredEvents = filteredEvents.filter(
+          (event) =>
+            event.categories !== undefined &&
+            options.tags?.some((tag) => event.categories?.includes(tag)),
+        );
+      }
+
+      // Limit the number of results if specified
+      if (options?.limit && options.limit > 0 && filteredEvents.length > options.limit) {
+        filteredEvents = filteredEvents.slice(0, options.limit);
+      }
+
+      this.logger.info(`Retrieved ${filteredEvents.length} events from calendar ${calendarId}`);
+      return filteredEvents;
+    } catch (error) {
+      this.logger.error(`Error fetching events for calendar ${calendarId}:`, error);
+      throw new Error(`Failed to fetch events: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Get a specific event by ID
+   * @param calendarId ID of the calendar containing the event
+   * @param eventId ID of the event to retrieve
+   * @returns Promise<Event> The requested event
+   */
+  async getEventById(calendarId: string, eventId: string): Promise<Event> {
+    this.logger.debug(`Fetching event ${eventId} from calendar ${calendarId}`);
+
+    try {
+      // Validate input
+      if (!calendarId) {
+        throw new Error('Calendar ID is required');
+      }
+
+      if (!eventId) {
+        throw new Error('Event ID is required');
+      }
+
+      // First approach: Try direct GET request to the event URL
+      const eventUrl = `${this.httpClient.getCalDavUrl()}${calendarId}/${eventId}.ics`;
+
+      try {
+        // Attempt to fetch the event directly
+        const iCalData = await this.httpClient.getEvent(eventUrl);
+
+        // Parse the iCalendar data
+        const events = iCalUtils.parseICalEvents(iCalData, calendarId);
+
+        if (events.length > 0) {
+          return events[0];
+        }
+      } catch (directFetchError) {
+        this.logger.warn(
+          `Direct fetch for event ${eventId} failed, trying REPORT approach`,
+          directFetchError,
+        );
+        // Continue to alternative approach if direct fetch fails
+      }
+
+      // Second approach: Use REPORT with UID filter
+      const reportXml = XmlUtils.buildEventByUidRequest(eventId);
+
+      // Send the REPORT request
+      const reportResponse = await this.httpClient.calendarReport(calendarId, reportXml);
+
+      // Parse the XML response
+      const xmlData = await XmlUtils.parseXmlResponse(reportResponse);
+
+      // Extract the event from the response
+      const multistatus = XmlUtils.getMultistatus(xmlData);
+
+      if (multistatus) {
+        const responses = XmlUtils.getResponses(multistatus);
+
+        for (const response of responses) {
+          try {
+            // Find successful propstat
+            const propstat = Array.isArray(response['d:propstat'])
+              ? response['d:propstat'].find(
+                  (ps: { 'd:status'?: string }) => ps['d:status'] === 'HTTP/1.1 200 OK',
+                )
+              : response['d:propstat'];
+
+            if (!propstat || !propstat['d:prop']) {
+              continue;
+            }
+
+            const prop = propstat['d:prop'];
+
+            // Get the calendar data (iCalendar format)
+            const calendarData = prop['c:calendar-data'] || prop['calendar-data'];
+
+            if (!calendarData) {
+              continue;
+            }
+
+            // Parse the iCalendar data
+            const events = iCalUtils.parseICalEvents(calendarData.toString(), calendarId);
+
+            // Find the event with the matching ID
+            const event = events.find((e) => e.id === eventId);
+
+            if (event) {
+              return event;
+            }
+          } catch (parseError) {
+            this.logger.warn('Error parsing event response:', parseError);
+          }
+        }
+      }
+
+      // If we get here, the event was not found
+      throw new Error(`Event with ID ${eventId} not found in calendar ${calendarId}`);
+    } catch (error) {
+      this.logger.error(`Error fetching event ${eventId} from calendar ${calendarId}:`, error);
+      throw new Error(`Failed to fetch event: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Create a new event in a calendar
+   * @param calendarId ID of the calendar to add the event to
+   * @param event Event object with properties for the new event
+   * @returns Promise<Event> The created event with server-assigned properties
+   */
+  async createEvent(
+    calendarId: string,
+    event: Omit<Event, 'id' | 'created' | 'lastModified'>,
+  ): Promise<Event> {
+    this.logger.debug(`Creating new event in calendar ${calendarId}`);
+
+    try {
+      // Validate input
+      if (!calendarId) {
+        throw new Error('Calendar ID is required');
+      }
+
+      if (!event.title) {
+        throw new Error('Event title is required');
+      }
+
+      if (!event.start || !event.end) {
+        throw new Error('Event start and end dates are required');
+      }
+
+      // Generate a unique ID for the event
+      const uuid = crypto.randomUUID();
+      const eventId = uuid.replace(/-/g, '');
+
+      // Create a complete event object
+      const now = new Date();
+      const completeEvent: Event = {
+        id: eventId,
+        calendarId: calendarId,
+        title: event.title,
+        description: event.description,
+        start: event.start,
+        end: event.end,
+        isAllDay: event.isAllDay || false,
+        location: event.location,
+        organizer: event.organizer,
+        participants: event.participants,
+        recurrenceRule: event.recurrenceRule,
+        status: event.status,
+        visibility: event.visibility,
+        availability: event.availability,
+        reminders: event.reminders,
+        color: event.color,
+        categories: event.categories,
+        adhdCategory: event.adhdCategory,
+        focusPriority: event.focusPriority,
+        energyLevel: event.energyLevel,
+        relatedTasks: event.relatedTasks,
+        created: now,
+        lastModified: now,
+        metadata: event.metadata,
+      };
+
+      // Generate iCalendar data
+      const iCalData = iCalUtils.generateICalEvent(completeEvent);
+
+      // Create the event via PUT request
+      const success = await this.httpClient.putEvent(calendarId, eventId, iCalData);
+
+      if (!success) {
+        throw new Error('Failed to create event, server did not acknowledge successful creation');
+      }
+
+      // Return the complete event object
+      this.logger.info(`Event ${eventId} created successfully in calendar ${calendarId}`);
+      return completeEvent;
+    } catch (error) {
+      this.logger.error(`Error creating event in calendar ${calendarId}:`, error);
+      throw new Error(`Failed to create event: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Update an existing event
+   * @param calendarId ID of the calendar containing the event
+   * @param eventId ID of the event to update
+   * @param updates Partial event object with updated properties
+   * @returns Promise<Event> The updated event
+   */
+  async updateEvent(calendarId: string, eventId: string, updates: Partial<Event>): Promise<Event> {
+    this.logger.debug(`Updating event ${eventId} in calendar ${calendarId}`);
+
+    try {
+      // Validate input
+      if (!calendarId) {
+        throw new Error('Calendar ID is required');
+      }
+
+      if (!eventId) {
+        throw new Error('Event ID is required');
+      }
+
+      if (!updates || Object.keys(updates).length === 0) {
+        throw new Error('No updates provided');
+      }
+
+      // Fetch the existing event
+      const currentEvent = await this.getEventById(calendarId, eventId);
+
+      if (!currentEvent) {
+        throw new Error(`Event ${eventId} not found in calendar ${calendarId}`);
+      }
+
+      // Merge the updates with the current event
+      const updatedEvent: Event = {
+        ...currentEvent,
+        ...updates,
+        id: eventId, // Ensure ID doesn't change
+        calendarId: calendarId, // Ensure calendar doesn't change
+        lastModified: new Date(), // Update the modification timestamp
+      };
+
+      // We need to fetch the event's ETag to avoid conflicts
+      // This involves making a direct request to the event URL
+      const eventUrl = `${this.httpClient.getCalDavUrl()}${calendarId}/${eventId}.ics`;
+      let etag = '';
+
+      try {
+        // Make a HEAD request to get the ETag
+        const response = await axios.head(eventUrl, {
+          headers: {
+            // Use a different approach to create the Basic auth header
+            Authorization: `Basic ${Buffer.from(`${this.config.username}:${this.config.appToken}`).toString('base64')}`,
+          },
+        });
+
+        etag = response.headers['etag'] || '';
+      } catch (etagError) {
+        this.logger.warn(
+          `Failed to fetch ETag for event ${eventId}, proceeding without optimistic concurrency control`,
+          etagError,
+        );
+      }
+
+      // Generate iCalendar data
+      const iCalData = iCalUtils.generateICalEvent(updatedEvent);
+
+      // Update the event via PUT request
+      let success: boolean;
+
+      if (etag) {
+        success = await this.httpClient.updateEvent(calendarId, eventId, iCalData, etag);
+      } else {
+        // Fallback without ETag
+        success = await this.httpClient.putEvent(calendarId, eventId, iCalData);
+      }
+
+      if (!success) {
+        throw new Error('Failed to update event, server did not acknowledge successful update');
+      }
+
+      // Return the updated event object
+      this.logger.info(`Event ${eventId} updated successfully in calendar ${calendarId}`);
+      return updatedEvent;
+    } catch (error) {
+      this.logger.error(`Error updating event ${eventId} in calendar ${calendarId}:`, error);
+      throw new Error(`Failed to update event: ${(error as Error).message}`);
+    }
+  }
+
+  /**
+   * Delete an event from a calendar
+   * @param calendarId ID of the calendar containing the event
+   * @param eventId ID of the event to delete
+   * @returns Promise<boolean> True if event was deleted successfully
+   */
+  async deleteEvent(calendarId: string, eventId: string): Promise<boolean> {
+    this.logger.debug(`Deleting event ${eventId} from calendar ${calendarId}`);
+
+    try {
+      // Validate input
+      if (!calendarId) {
+        throw new Error('Calendar ID is required');
+      }
+
+      if (!eventId) {
+        throw new Error('Event ID is required');
+      }
+
+      // Verify the event exists before attempting to delete it
+      try {
+        await this.getEventById(calendarId, eventId);
+      } catch (error) {
+        // If the event doesn't exist, log a warning but don't fail (idempotent delete)
+        if ((error as Error).message.includes('not found')) {
+          this.logger.warn(
+            `Event ${eventId} not found in calendar ${calendarId}, treating delete as success`,
+          );
+          return true;
+        }
+        // Re-throw any other errors
+        throw error;
+      }
+
+      // Delete the event via DELETE request
+      const success = await this.httpClient.deleteEvent(calendarId, eventId);
+
+      if (!success) {
+        throw new Error('Failed to delete event, server did not acknowledge successful deletion');
+      }
+
+      this.logger.info(`Event ${eventId} deleted successfully from calendar ${calendarId}`);
+      return true;
+    } catch (error) {
+      // Special case: if the error is that the event wasn't found, treat as success
+      if ((error as Error).message.includes('not found')) {
+        this.logger.warn(`Event ${eventId} was already deleted, treating as success`);
+        return true;
+      }
+
+      this.logger.error(`Error deleting event ${eventId} from calendar ${calendarId}:`, error);
+      throw new Error(`Failed to delete event: ${(error as Error).message}`);
+    }
+  }
+}

--- a/src/services/calendar/event-service.ts
+++ b/src/services/calendar/event-service.ts
@@ -35,6 +35,30 @@ export class EventService {
   }
 
   /**
+   * Validate a calendar ID
+   * @param calendarId The calendar ID to validate
+   * @throws Error if the calendar ID is invalid
+   * @private Internal utility method
+   */
+  private validateCalendarId(calendarId: string): void {
+    if (!calendarId) {
+      throw new Error('Calendar ID is required');
+    }
+
+    // Calendar IDs should follow a specific format:
+    // - Only alphanumeric characters, hyphens, underscores, and periods
+    // - Cannot contain path traversal sequences
+    const safeIdRegex = /^[a-zA-Z0-9_.-]+$/;
+
+    if (!safeIdRegex.test(calendarId)) {
+      this.logger.error(`Invalid calendar ID format: ${calendarId}`);
+      throw new Error(
+        'Invalid calendar ID format: Only alphanumeric characters, dash, underscore, and period are allowed',
+      );
+    }
+  }
+
+  /**
    * Get events from a calendar with optional filtering
    * @param calendarId ID of the calendar to get events from
    * @param options Optional filtering parameters
@@ -56,9 +80,7 @@ export class EventService {
 
     try {
       // Validate calendar ID
-      if (!calendarId) {
-        throw new Error('Calendar ID is required');
-      }
+      this.validateCalendarId(calendarId);
 
       // Build the REPORT request for calendar events
       const reportXml = XmlUtils.buildEventsReportRequest(options?.start, options?.end);
@@ -186,6 +208,30 @@ export class EventService {
   }
 
   /**
+   * Validate an event ID
+   * @param eventId The event ID to validate
+   * @throws Error if the event ID is invalid
+   * @private Internal utility method
+   */
+  private validateEventId(eventId: string): void {
+    if (!eventId) {
+      throw new Error('Event ID is required');
+    }
+
+    // Event IDs should follow a specific format:
+    // - Only alphanumeric characters, hyphens, underscores, and periods
+    // - Cannot contain path traversal sequences
+    const safeIdRegex = /^[a-zA-Z0-9_.-]+$/;
+
+    if (!safeIdRegex.test(eventId)) {
+      this.logger.error(`Invalid event ID format: ${eventId}`);
+      throw new Error(
+        'Invalid event ID format: Only alphanumeric characters, dash, underscore, and period are allowed',
+      );
+    }
+  }
+
+  /**
    * Get a specific event by ID
    * @param calendarId ID of the calendar containing the event
    * @param eventId ID of the event to retrieve
@@ -196,13 +242,8 @@ export class EventService {
 
     try {
       // Validate input
-      if (!calendarId) {
-        throw new Error('Calendar ID is required');
-      }
-
-      if (!eventId) {
-        throw new Error('Event ID is required');
-      }
+      this.validateCalendarId(calendarId);
+      this.validateEventId(eventId);
 
       // First approach: Try direct GET request to the event URL
       const eventUrl = `${this.httpClient.getCalDavUrl()}${calendarId}/${eventId}.ics`;
@@ -299,9 +340,7 @@ export class EventService {
 
     try {
       // Validate input
-      if (!calendarId) {
-        throw new Error('Calendar ID is required');
-      }
+      this.validateCalendarId(calendarId);
 
       if (!event.title) {
         throw new Error('Event title is required');
@@ -375,13 +414,8 @@ export class EventService {
 
     try {
       // Validate input
-      if (!calendarId) {
-        throw new Error('Calendar ID is required');
-      }
-
-      if (!eventId) {
-        throw new Error('Event ID is required');
-      }
+      this.validateCalendarId(calendarId);
+      this.validateEventId(eventId);
 
       if (!updates || Object.keys(updates).length === 0) {
         throw new Error('No updates provided');
@@ -467,6 +501,9 @@ export class EventService {
     start?: Date,
     end?: Date,
   ): Promise<Event[]> {
+    // Validate calendar ID
+    this.validateCalendarId(calendarId);
+
     // Default dates if not provided
     const startDate = start || new Date();
     const endDate = end || new Date(startDate.getTime() + 90 * 24 * 60 * 60 * 1000); // Default to 90 days ahead
@@ -563,13 +600,8 @@ export class EventService {
 
     try {
       // Validate input
-      if (!calendarId) {
-        throw new Error('Calendar ID is required');
-      }
-
-      if (!eventId) {
-        throw new Error('Event ID is required');
-      }
+      this.validateCalendarId(calendarId);
+      this.validateEventId(eventId);
 
       // Verify the event exists before attempting to delete it
       try {

--- a/src/services/calendar/ical-utils.ts
+++ b/src/services/calendar/ical-utils.ts
@@ -1,0 +1,689 @@
+/**
+ * Utilities for handling iCalendar format data
+ */
+import { Event, RecurrenceRule, EventReminder } from '../../models/index.js';
+import { createLogger } from '../logger.js';
+import * as crypto from 'crypto';
+
+const logger = createLogger('iCalUtils');
+
+/**
+ * Extract events from an iCalendar string
+ * @param iCalData The iCalendar data in string format
+ * @param calendarId The ID of the calendar containing the events
+ * @returns An array of Event objects
+ */
+export function parseICalEvents(iCalData: string, calendarId: string): Event[] {
+  try {
+    logger.debug('Parsing iCalendar data');
+
+    const events: Event[] = [];
+
+    // NOTE: This is a simplified parser for demonstration
+    // In a production environment, we would use a proper iCalendar library
+    // such as ical.js or node-ical
+
+    // Split the iCalendar data into components
+    const components = splitICalComponents(iCalData);
+
+    // Find all VEVENT components
+    components.forEach((component) => {
+      if (component.startsWith('BEGIN:VEVENT') && component.endsWith('END:VEVENT')) {
+        try {
+          const event = parseEventComponent(component, calendarId);
+          if (event) {
+            events.push(event);
+          }
+        } catch (parseError) {
+          logger.warn('Error parsing event component:', parseError);
+        }
+      }
+    });
+
+    logger.debug(`Parsed ${events.length} events from iCalendar data`);
+    return events;
+  } catch (err) {
+    logger.error('Error parsing iCalendar data:', err);
+    throw new Error(`Failed to parse iCalendar data: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Generate an iCalendar string from an Event object
+ * @param event The Event object to convert to iCalendar format
+ * @returns An iCalendar string representing the event
+ */
+export function generateICalEvent(event: Event): string {
+  try {
+    logger.debug(`Generating iCalendar data for event ${event.id}`);
+
+    // Format dates in the iCalendar format (YYYYMMDDTHHMMSSZ)
+    const formatDate = (date: Date, isAllDay = false): string => {
+      if (isAllDay) {
+        return date.toISOString().substring(0, 10).replace(/-/g, '');
+      } else {
+        return date
+          .toISOString()
+          .replace(/[-:]/g, '')
+          .replace(/\.\d{3}/, '');
+      }
+    };
+
+    // Generate a unique ID if one doesn't exist
+    const eventId = event.id || generateUid();
+
+    // Build the iCalendar string
+    let iCal = 'BEGIN:VCALENDAR\r\n';
+    iCal += 'VERSION:2.0\r\n';
+    iCal += 'PRODID:-//Nextcloud Calendar//EN\r\n';
+    iCal += 'CALSCALE:GREGORIAN\r\n';
+
+    // Event component
+    iCal += 'BEGIN:VEVENT\r\n';
+    iCal += `UID:${eventId}\r\n`;
+
+    // Event created/modified timestamps
+    iCal += `DTSTAMP:${formatDate(new Date())}\r\n`;
+    if (event.created) {
+      iCal += `CREATED:${formatDate(event.created)}\r\n`;
+    }
+    if (event.lastModified) {
+      iCal += `LAST-MODIFIED:${formatDate(event.lastModified)}\r\n`;
+    }
+
+    // Event dates
+    if (event.isAllDay) {
+      iCal += `DTSTART;VALUE=DATE:${formatDate(event.start, true)}\r\n`;
+      // For all-day events, the end date is exclusive
+      const endDate = new Date(event.end);
+      endDate.setDate(endDate.getDate() + 1);
+      iCal += `DTEND;VALUE=DATE:${formatDate(endDate, true)}\r\n`;
+    } else {
+      iCal += `DTSTART:${formatDate(event.start)}\r\n`;
+      iCal += `DTEND:${formatDate(event.end)}\r\n`;
+    }
+
+    // Event title and description
+    iCal += `SUMMARY:${escapeICalString(event.title)}\r\n`;
+    if (event.description) {
+      iCal += `DESCRIPTION:${escapeICalString(event.description)}\r\n`;
+    }
+
+    // Location
+    if (event.location) {
+      iCal += `LOCATION:${escapeICalString(event.location)}\r\n`;
+    }
+
+    // Status
+    if (event.status) {
+      iCal += `STATUS:${event.status.toUpperCase()}\r\n`;
+    }
+
+    // Class (visibility)
+    if (event.visibility) {
+      let classValue: string;
+      switch (event.visibility) {
+        case 'private':
+          classValue = 'PRIVATE';
+          break;
+        case 'confidential':
+          classValue = 'CONFIDENTIAL';
+          break;
+        default:
+          classValue = 'PUBLIC';
+      }
+      iCal += `CLASS:${classValue}\r\n`;
+    }
+
+    // Transparency (availability)
+    if (event.availability) {
+      iCal += `TRANSP:${event.availability === 'free' ? 'TRANSPARENT' : 'OPAQUE'}\r\n`;
+    }
+
+    // Organizer
+    if (event.organizer) {
+      iCal += `ORGANIZER:MAILTO:${event.organizer}\r\n`;
+    }
+
+    // Participants (attendees)
+    if (event.participants && event.participants.length > 0) {
+      event.participants.forEach((participant) => {
+        let attendee = `ATTENDEE;CN=${escapeICalString(participant.name || participant.email)}`;
+
+        // Role
+        if (participant.role) {
+          attendee += `;ROLE=${participant.role === 'required' ? 'REQ-PARTICIPANT' : 'OPT-PARTICIPANT'}`;
+        }
+
+        // Participation status
+        if (participant.status) {
+          let partstatValue: string;
+          switch (participant.status) {
+            case 'accepted':
+              partstatValue = 'ACCEPTED';
+              break;
+            case 'declined':
+              partstatValue = 'DECLINED';
+              break;
+            case 'tentative':
+              partstatValue = 'TENTATIVE';
+              break;
+            default:
+              partstatValue = 'NEEDS-ACTION';
+          }
+          attendee += `;PARTSTAT=${partstatValue}`;
+        }
+
+        // Type
+        if (participant.type) {
+          attendee += `;CUTYPE=${participant.type.toUpperCase()}`;
+        }
+
+        attendee += `:MAILTO:${participant.email}\r\n`;
+        iCal += attendee;
+      });
+    }
+
+    // Categories
+    if (event.categories && event.categories.length > 0) {
+      iCal += `CATEGORIES:${event.categories.map(escapeICalString).join(',')}\r\n`;
+    }
+
+    // Color
+    if (event.color) {
+      // X-APPLE-CALENDAR-COLOR is a common extension for calendar color
+      iCal += `X-APPLE-CALENDAR-COLOR:${event.color}\r\n`;
+    }
+
+    // ADHD-specific properties (using X- prefixed custom properties)
+    if (event.adhdCategory) {
+      iCal += `X-ADHD-CATEGORY:${escapeICalString(event.adhdCategory)}\r\n`;
+    }
+
+    if (event.focusPriority !== undefined) {
+      iCal += `X-ADHD-FOCUS-PRIORITY:${event.focusPriority}\r\n`;
+    }
+
+    if (event.energyLevel !== undefined) {
+      iCal += `X-ADHD-ENERGY-LEVEL:${event.energyLevel}\r\n`;
+    }
+
+    // Related tasks
+    if (event.relatedTasks && event.relatedTasks.length > 0) {
+      event.relatedTasks.forEach((task) => {
+        iCal += `X-ADHD-RELATED-TASK:${escapeICalString(task)}\r\n`;
+      });
+    }
+
+    // Recurrence rule
+    if (event.recurrenceRule) {
+      iCal += generateRecurrenceRule(event.recurrenceRule);
+    }
+
+    // Alarms (reminders)
+    if (event.reminders && event.reminders.length > 0) {
+      event.reminders.forEach((reminder) => {
+        iCal += generateAlarm(reminder);
+      });
+    }
+
+    iCal += 'END:VEVENT\r\n';
+    iCal += 'END:VCALENDAR\r\n';
+
+    return iCal;
+  } catch (err) {
+    logger.error('Error generating iCalendar data:', err);
+    throw new Error(`Failed to generate iCalendar data: ${(err as Error).message}`);
+  }
+}
+
+/**
+ * Split an iCalendar string into its components
+ * @param iCalData The iCalendar data
+ * @returns Array of component strings
+ */
+function splitICalComponents(iCalData: string): string[] {
+  const components: string[] = [];
+  let currentComponent = '';
+  let inComponent = false;
+  let componentDepth = 0;
+  let componentType = '';
+
+  // Normalize line endings and split into lines
+  const lines = iCalData.replace(/\r\n|\n\r|\n|\r/g, '\r\n').split('\r\n');
+
+  for (const line of lines) {
+    if (line.startsWith('BEGIN:')) {
+      componentDepth++;
+
+      if (componentDepth === 1) {
+        // Start of a root component
+        currentComponent = line;
+        inComponent = true;
+        componentType = line.substring(6); // Extract component type
+      } else {
+        // Nested component
+        currentComponent += '\r\n' + line;
+      }
+    } else if (line.startsWith('END:')) {
+      const endType = line.substring(4);
+
+      if (componentDepth === 1 && endType === componentType) {
+        // End of a root component
+        currentComponent += '\r\n' + line;
+        components.push(currentComponent);
+        currentComponent = '';
+        inComponent = false;
+        componentDepth = 0;
+        componentType = '';
+      } else {
+        // End of a nested component
+        currentComponent += '\r\n' + line;
+        componentDepth--;
+      }
+    } else if (inComponent) {
+      // Part of the current component
+      currentComponent += '\r\n' + line;
+    }
+  }
+
+  return components;
+}
+
+/**
+ * Parse a VEVENT component into an Event object
+ * @param eventData The VEVENT component string
+ * @param calendarId The ID of the calendar containing the event
+ * @returns An Event object or null if parsing fails
+ */
+function parseEventComponent(eventData: string, calendarId: string): Event | null {
+  try {
+    // Split into lines and create a property map
+    const lines = eventData.split('\r\n').filter((line) => line.trim() !== '');
+    const props: Record<string, string> = {};
+
+    // Parse each line
+    lines.forEach((line) => {
+      if (!line.includes(':')) return;
+
+      // Handle property parameters like DTSTART;VALUE=DATE:
+      const colonPos = line.indexOf(':');
+      let propName = line.substring(0, colonPos);
+      const propValue = line.substring(colonPos + 1);
+
+      // Extract base property name if it has parameters
+      const semiPos = propName.indexOf(';');
+      if (semiPos > 0) {
+        propName = propName.substring(0, semiPos);
+      }
+
+      props[propName] = propValue;
+    });
+
+    // Extract basic properties
+    const uid = props['UID'] || '';
+    if (!uid) return null;
+
+    const summary = props['SUMMARY'] || 'Untitled Event';
+
+    // Parse dates
+    let start: Date | null = null;
+    let end: Date | null = null;
+    let isAllDay = false;
+
+    // Handle all-day events
+    if (lines.some((line) => line.startsWith('DTSTART;VALUE=DATE:'))) {
+      isAllDay = true;
+      const startDate = lines.find((line) => line.startsWith('DTSTART'))?.split(':')[1];
+      const endDate = lines.find((line) => line.startsWith('DTEND'))?.split(':')[1];
+
+      if (startDate) {
+        start = parseICalDate(startDate);
+      }
+
+      if (endDate) {
+        // For all-day events, the end date is exclusive
+        end = parseICalDate(endDate);
+        if (end) {
+          end.setDate(end.getDate() - 1);
+        }
+      }
+    } else {
+      // Regular events with time
+      const startTime = props['DTSTART'];
+      const endTime = props['DTEND'];
+
+      if (startTime) {
+        start = parseICalDateTime(startTime);
+      }
+
+      if (endTime) {
+        end = parseICalDateTime(endTime);
+      }
+    }
+
+    // If we couldn't parse the dates, can't create a valid event
+    if (!start || !end) return null;
+
+    // Parse creation/modification dates
+    const created = props['CREATED']
+      ? parseICalDateTime(props['CREATED']) || new Date()
+      : new Date();
+    const lastModified = props['LAST-MODIFIED']
+      ? parseICalDateTime(props['LAST-MODIFIED']) || new Date()
+      : new Date();
+
+    // Create basic event
+    const event: Event = {
+      id: uid,
+      calendarId: calendarId,
+      title: unescapeICalString(summary),
+      description: props['DESCRIPTION'] ? unescapeICalString(props['DESCRIPTION']) : undefined,
+      start: start,
+      end: end,
+      isAllDay: isAllDay,
+      location: props['LOCATION'] ? unescapeICalString(props['LOCATION']) : undefined,
+      organizer: props['ORGANIZER'] ? extractEmailFromCalAddress(props['ORGANIZER']) : undefined,
+      created: created,
+      lastModified: lastModified,
+    };
+
+    // Status
+    if (props['STATUS']) {
+      const status = props['STATUS'].toLowerCase();
+      if (status === 'confirmed' || status === 'tentative' || status === 'cancelled') {
+        event.status = status as 'confirmed' | 'tentative' | 'cancelled';
+      }
+    }
+
+    // Visibility (CLASS)
+    if (props['CLASS']) {
+      const visibility = props['CLASS'].toLowerCase();
+      if (visibility === 'public' || visibility === 'private' || visibility === 'confidential') {
+        event.visibility = visibility as 'public' | 'private' | 'confidential';
+      }
+    }
+
+    // Availability (TRANSP)
+    if (props['TRANSP']) {
+      event.availability = props['TRANSP'] === 'TRANSPARENT' ? 'free' : 'busy';
+    }
+
+    // Categories
+    if (props['CATEGORIES']) {
+      event.categories = props['CATEGORIES'].split(',').map(unescapeICalString);
+    }
+
+    // Custom ADHD properties
+    const adhdProps: Record<string, string[]> = {};
+
+    lines.forEach((line) => {
+      if (line.startsWith('X-ADHD-')) {
+        const colonPos = line.indexOf(':');
+        if (colonPos > 0) {
+          const propName = line.substring(0, colonPos);
+          const propValue = line.substring(colonPos + 1);
+
+          if (!adhdProps[propName]) {
+            adhdProps[propName] = [];
+          }
+          adhdProps[propName].push(propValue);
+        }
+      }
+    });
+
+    if (adhdProps['X-ADHD-CATEGORY'] && adhdProps['X-ADHD-CATEGORY'].length > 0) {
+      event.adhdCategory = unescapeICalString(adhdProps['X-ADHD-CATEGORY'][0]);
+    }
+
+    if (adhdProps['X-ADHD-FOCUS-PRIORITY'] && adhdProps['X-ADHD-FOCUS-PRIORITY'].length > 0) {
+      const priority = parseInt(adhdProps['X-ADHD-FOCUS-PRIORITY'][0], 10);
+      if (!isNaN(priority) && priority >= 1 && priority <= 10) {
+        event.focusPriority = priority;
+      }
+    }
+
+    if (adhdProps['X-ADHD-ENERGY-LEVEL'] && adhdProps['X-ADHD-ENERGY-LEVEL'].length > 0) {
+      const level = parseInt(adhdProps['X-ADHD-ENERGY-LEVEL'][0], 10);
+      if (!isNaN(level) && level >= 1 && level <= 5) {
+        event.energyLevel = level;
+      }
+    }
+
+    if (adhdProps['X-ADHD-RELATED-TASK']) {
+      event.relatedTasks = adhdProps['X-ADHD-RELATED-TASK'].map(unescapeICalString);
+    }
+
+    // TODO: Add recurrence and attendee parsing
+
+    return event;
+  } catch {
+    // Error is logged but not used
+    logger.warn('Error parsing event component');
+    return null;
+  }
+}
+
+/**
+ * Parse a date from iCalendar format (e.g., "20210315" for March 15, 2021)
+ * @param dateStr The date string in iCalendar format
+ * @returns A Date object or null if invalid
+ */
+function parseICalDate(dateStr: string): Date | null {
+  if (!dateStr || dateStr.length < 8) return null;
+
+  try {
+    const year = parseInt(dateStr.substring(0, 4), 10);
+    const month = parseInt(dateStr.substring(4, 6), 10) - 1; // Months are 0-based in JS
+    const day = parseInt(dateStr.substring(6, 8), 10);
+
+    return new Date(year, month, day);
+  } catch {
+    // On error, return null
+    return null;
+  }
+}
+
+/**
+ * Parse a date and time from iCalendar format (e.g., "20210315T143000Z")
+ * @param dateTimeStr The date-time string in iCalendar format
+ * @returns A Date object or null if invalid
+ */
+function parseICalDateTime(dateTimeStr: string): Date | null {
+  if (!dateTimeStr || dateTimeStr.length < 8) return null;
+
+  try {
+    // Check if it's just a date (no time component)
+    if (dateTimeStr.length === 8) {
+      return parseICalDate(dateTimeStr);
+    }
+
+    // Remove the 'Z' at the end if present
+    const isUTC = dateTimeStr.endsWith('Z');
+    const cleanStr = isUTC ? dateTimeStr.substring(0, dateTimeStr.length - 1) : dateTimeStr;
+
+    // Check for the 'T' separator
+    const tPos = cleanStr.indexOf('T');
+    if (tPos <= 0) {
+      // No time component, just a date
+      return parseICalDate(cleanStr);
+    }
+
+    // Split into date and time parts
+    const dateStr = cleanStr.substring(0, tPos);
+    const timeStr = cleanStr.substring(tPos + 1);
+
+    // Parse date
+    const year = parseInt(dateStr.substring(0, 4), 10);
+    const month = parseInt(dateStr.substring(4, 6), 10) - 1; // Months are 0-based in JS
+    const day = parseInt(dateStr.substring(6, 8), 10);
+
+    // Parse time
+    let hour = 0,
+      minute = 0,
+      second = 0;
+
+    if (timeStr.length >= 2) {
+      hour = parseInt(timeStr.substring(0, 2), 10);
+    }
+
+    if (timeStr.length >= 4) {
+      minute = parseInt(timeStr.substring(2, 4), 10);
+    }
+
+    if (timeStr.length >= 6) {
+      second = parseInt(timeStr.substring(4, 6), 10);
+    }
+
+    if (isUTC) {
+      return new Date(Date.UTC(year, month, day, hour, minute, second));
+    } else {
+      return new Date(year, month, day, hour, minute, second);
+    }
+  } catch {
+    // On error, return null
+    return null;
+  }
+}
+
+/**
+ * Generate a UID for a new event
+ * @returns A unique ID string
+ */
+function generateUid(): string {
+  const timestamp = new Date().getTime();
+  const random = crypto.randomBytes(8).toString('hex');
+  return `${timestamp}-${random}@nextcloud-calendar`;
+}
+
+/**
+ * Generate an iCalendar RRULE string from a RecurrenceRule object
+ * @param rule The RecurrenceRule object
+ * @returns An iCalendar RRULE string
+ */
+function generateRecurrenceRule(rule: RecurrenceRule): string {
+  let rrule = 'RRULE:FREQ=' + rule.frequency.toUpperCase();
+
+  if (rule.interval && rule.interval > 0) {
+    rrule += `;INTERVAL=${rule.interval}`;
+  }
+
+  if (rule.until) {
+    // Format the until date in UTC
+    const untilStr =
+      rule.until
+        .toISOString()
+        .replace(/[-:]/g, '')
+        .replace(/\.\d{3}/, '')
+        .substring(0, 15) + 'Z';
+    rrule += `;UNTIL=${untilStr}`;
+  }
+
+  if (rule.count && rule.count > 0) {
+    rrule += `;COUNT=${rule.count}`;
+  }
+
+  if (rule.byDay && rule.byDay.length > 0) {
+    rrule += `;BYDAY=${rule.byDay.join(',')}`;
+  }
+
+  if (rule.byMonthDay && rule.byMonthDay.length > 0) {
+    rrule += `;BYMONTHDAY=${rule.byMonthDay.join(',')}`;
+  }
+
+  if (rule.byMonth && rule.byMonth.length > 0) {
+    rrule += `;BYMONTH=${rule.byMonth.join(',')}`;
+  }
+
+  if (rule.bySetPos && rule.bySetPos.length > 0) {
+    rrule += `;BYSETPOS=${rule.bySetPos.join(',')}`;
+  }
+
+  rrule += '\r\n';
+
+  // Add EXDATE properties for excluded dates
+  if (rule.exDates && rule.exDates.length > 0) {
+    rule.exDates.forEach((exDate) => {
+      const exDateStr =
+        exDate
+          .toISOString()
+          .replace(/[-:]/g, '')
+          .replace(/\.\d{3}/, '')
+          .substring(0, 15) + 'Z';
+      rrule += `EXDATE:${exDateStr}\r\n`;
+    });
+  }
+
+  return rrule;
+}
+
+/**
+ * Generate an iCalendar VALARM component from an EventReminder object
+ * @param reminder The EventReminder object
+ * @returns An iCalendar VALARM string
+ */
+function generateAlarm(reminder: EventReminder): string {
+  let alarm = 'BEGIN:VALARM\r\n';
+
+  // The action depends on the reminder type
+  if (reminder.type === 'email') {
+    alarm += 'ACTION:EMAIL\r\n';
+    alarm += 'DESCRIPTION:Reminder\r\n';
+  } else {
+    alarm += 'ACTION:DISPLAY\r\n';
+    alarm += 'DESCRIPTION:Reminder\r\n';
+  }
+
+  // Set the trigger (minutes before the event)
+  alarm += `TRIGGER:-PT${reminder.minutesBefore}M\r\n`;
+
+  alarm += 'END:VALARM\r\n';
+  return alarm;
+}
+
+/**
+ * Extract an email address from a CAL-ADDRESS value
+ * @param calAddress The CAL-ADDRESS value (e.g., "MAILTO:user@example.com")
+ * @returns The extracted email address
+ */
+function extractEmailFromCalAddress(calAddress: string): string {
+  const mailtoPrefix = 'MAILTO:';
+
+  if (calAddress.includes(mailtoPrefix)) {
+    return calAddress.substring(calAddress.lastIndexOf(mailtoPrefix) + mailtoPrefix.length);
+  }
+
+  return calAddress;
+}
+
+/**
+ * Escape special characters in a string for iCalendar format
+ * @param input The string to escape
+ * @returns The escaped string
+ */
+function escapeICalString(input: string | null | undefined): string {
+  if (input === null || input === undefined) {
+    return '';
+  }
+
+  return String(input)
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\n/g, '\\n');
+}
+
+/**
+ * Unescape special characters in a string from iCalendar format
+ * @param input The string to unescape
+ * @returns The unescaped string
+ */
+function unescapeICalString(input: string): string {
+  if (!input) return '';
+
+  return input
+    .replace(/\\n/g, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+}

--- a/src/services/calendar/index.ts
+++ b/src/services/calendar/index.ts
@@ -2,6 +2,8 @@
  * Calendar service exports
  */
 export * from './calendar-service.js';
+export * from './event-service.js';
 export * from './http-client.js';
 export * as XmlUtils from './xml-utils.js';
 export * as PropertyParser from './property-parser.js';
+export * as iCalUtils from './ical-utils.js';

--- a/src/services/calendar/xml-utils.ts
+++ b/src/services/calendar/xml-utils.ts
@@ -218,6 +218,11 @@ export function getResponses(multistatus: Record<string, unknown>): Array<Record
  * @param start Start date of the range (optional)
  * @param end End date of the range (optional)
  * @returns XML string for the REPORT request
+ *
+ * TODO: Enhance this method to support additional server-side filtering options beyond time range,
+ * such as filtering by categories, status, or other standardized properties to improve performance
+ * with large calendars. This can be done by adding additional comp-filter and prop-filter elements
+ * to the filter section.
  */
 export function buildEventsReportRequest(start?: Date, end?: Date): string {
   // Default time range if not specified: +/- 6 months from current date

--- a/src/services/calendar/xml-utils.ts
+++ b/src/services/calendar/xml-utils.ts
@@ -54,7 +54,7 @@ export function buildCalendarPropertiesRequest(): string {
  */
 export function buildMkcalendarXml(displayName: string): string {
   const safeDisplayName = escapeXml(displayName);
-  
+
   return `<?xml version="1.0" encoding="UTF-8"?>
     <x0:mkcalendar xmlns:x0="urn:ietf:params:xml:ns:caldav">
       <x0:set>
@@ -77,15 +77,14 @@ export function buildCalendarPropertiesXml(
   displayName: string,
   color: string = '#0082c9',
   category?: string | null,
-  focusPriority?: number | null
+  focusPriority?: number | null,
 ): string {
   const safeDisplayName = escapeXml(displayName);
   const safeColor = escapeXml(color);
   const safeCategory = category ? escapeXml(category) : '';
-  const safeFocusPriority = focusPriority !== undefined && focusPriority !== null 
-    ? escapeXml(String(focusPriority)) 
-    : '';
-  
+  const safeFocusPriority =
+    focusPriority !== undefined && focusPriority !== null ? escapeXml(String(focusPriority)) : '';
+
   return `<?xml version="1.0" encoding="UTF-8"?>
     <x0:propertyupdate xmlns:x0="DAV:" xmlns:x1="http://apple.com/ns/ical/"
                       xmlns:x2="http://owncloud.org/ns" xmlns:x3="http://calendarserver.org/ns/">
@@ -105,7 +104,9 @@ export function buildCalendarPropertiesXml(
  * @param properties Object with property names and values to update
  * @returns XML string for updating specific properties
  */
-export function buildPartialPropertiesXml(properties: Record<string, string | number | null | undefined>): string {
+export function buildPartialPropertiesXml(
+  properties: Record<string, string | number | null | undefined>,
+): string {
   let propXml = '';
 
   if (properties.displayName !== undefined) {
@@ -148,26 +149,27 @@ export async function parseXmlResponse(xmlString: string): Promise<Record<string
       // Normalize tag names to handle different Nextcloud versions
       normalizeTags: true,
       // Make attribute names more consistent
-      normalize: true
+      normalize: true,
     });
   } catch (parseError) {
     logger.warn('Initial XML parsing failed, trying with alternative options:', parseError);
     // Try again with different options
     return await parseStringPromise(xmlString, {
       explicitArray: true,
-      normalizeTags: true
+      normalizeTags: true,
     });
   }
 }
 
 /**
- * Safely navigate the multistatus response 
+ * Safely navigate the multistatus response
  * @param xmlData The parsed XML data
  * @returns The multistatus element or null if not found
  */
 export function getMultistatus(xmlData: Record<string, unknown>): Record<string, unknown> | null {
   // Try different possible paths to find the multistatus element
-  if (xmlData && xmlData['d:multistatus']) return xmlData['d:multistatus'] as Record<string, unknown>;
+  if (xmlData && xmlData['d:multistatus'])
+    return xmlData['d:multistatus'] as Record<string, unknown>;
   if (xmlData && xmlData['multistatus']) return xmlData['multistatus'] as Record<string, unknown>;
 
   // Try to find any property that might contain 'multistatus' in a case-insensitive way
@@ -188,23 +190,123 @@ export function getMultistatus(xmlData: Record<string, unknown>): Record<string,
  * @returns Array of response elements
  */
 export function getResponses(multistatus: Record<string, unknown>): Array<Record<string, unknown>> {
-  if (multistatus['d:response']) return Array.isArray(multistatus['d:response']) 
-    ? multistatus['d:response'] as Array<Record<string, unknown>>
-    : [multistatus['d:response'] as Record<string, unknown>];
-    
-  if (multistatus['response']) return Array.isArray(multistatus['response'])
-    ? multistatus['response'] as Array<Record<string, unknown>>
-    : [multistatus['response'] as Record<string, unknown>];
+  if (multistatus['d:response'])
+    return Array.isArray(multistatus['d:response'])
+      ? (multistatus['d:response'] as Array<Record<string, unknown>>)
+      : [multistatus['d:response'] as Record<string, unknown>];
+
+  if (multistatus['response'])
+    return Array.isArray(multistatus['response'])
+      ? (multistatus['response'] as Array<Record<string, unknown>>)
+      : [multistatus['response'] as Record<string, unknown>];
 
   // Look for any key containing 'response'
   for (const key of Object.keys(multistatus)) {
     if (key.toLowerCase().includes('response')) {
       const responseElement = multistatus[key];
       return Array.isArray(responseElement)
-        ? responseElement as Array<Record<string, unknown>>
+        ? (responseElement as Array<Record<string, unknown>>)
         : [responseElement as Record<string, unknown>];
     }
   }
 
   return [];
+}
+
+/**
+ * Build a CalDAV REPORT request to fetch events within a time range
+ * @param start Start date of the range (optional)
+ * @param end End date of the range (optional)
+ * @returns XML string for the REPORT request
+ */
+export function buildEventsReportRequest(start?: Date, end?: Date): string {
+  // Default time range if not specified: +/- 6 months from current date
+  const now = new Date();
+  const defaultStart = new Date(now.getFullYear(), now.getMonth() - 6, 1);
+  const defaultEnd = new Date(now.getFullYear(), now.getMonth() + 6, 0);
+
+  const startDate = start || defaultStart;
+  const endDate = end || defaultEnd;
+
+  // Format dates as UTC strings in the format YYYYMMDDTHHMMSSZ
+  const formatUTCDate = (date: Date): string => {
+    return date
+      .toISOString()
+      .replace(/[-:]/g, '')
+      .replace(/\.\d{3}/, '');
+  };
+
+  return `<?xml version="1.0" encoding="utf-8" ?>
+    <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+      <d:prop>
+        <d:getetag />
+        <c:calendar-data />
+      </d:prop>
+      <c:filter>
+        <c:comp-filter name="VCALENDAR">
+          <c:comp-filter name="VEVENT">
+            <c:time-range start="${formatUTCDate(startDate)}" end="${formatUTCDate(endDate)}" />
+          </c:comp-filter>
+        </c:comp-filter>
+      </c:filter>
+    </c:calendar-query>`;
+}
+
+/**
+ * Build a CalDAV REPORT request to fetch a specific event by UID
+ * @param uid The event UID to fetch
+ * @returns XML string for the REPORT request
+ */
+export function buildEventByUidRequest(uid: string): string {
+  const safeUid = escapeXml(uid);
+
+  return `<?xml version="1.0" encoding="utf-8" ?>
+    <c:calendar-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+      <d:prop>
+        <d:getetag />
+        <c:calendar-data />
+      </d:prop>
+      <c:filter>
+        <c:comp-filter name="VCALENDAR">
+          <c:comp-filter name="VEVENT">
+            <c:prop-filter name="UID">
+              <c:text-match collation="i;unicode-casemap">${safeUid}</c:text-match>
+            </c:prop-filter>
+          </c:comp-filter>
+        </c:comp-filter>
+      </c:filter>
+    </c:calendar-query>`;
+}
+
+/**
+ * Build a request to expand recurring events
+ * @param start Start date for expansion
+ * @param end End date for expansion
+ * @returns XML string for the calendar-multiget REPORT request
+ */
+export function buildExpandRecurringEventsRequest(
+  eventUrls: string[],
+  start: Date,
+  end: Date,
+): string {
+  // Format dates as UTC strings in the format YYYYMMDDTHHMMSSZ
+  const formatUTCDate = (date: Date): string => {
+    return date
+      .toISOString()
+      .replace(/[-:]/g, '')
+      .replace(/\.\d{3}/, '');
+  };
+
+  const hrefElements = eventUrls.map((url) => `<d:href>${escapeXml(url)}</d:href>`).join('');
+
+  return `<?xml version="1.0" encoding="utf-8" ?>
+    <c:calendar-multiget xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav">
+      <d:prop>
+        <d:getetag />
+        <c:calendar-data>
+          <c:expand start="${formatUTCDate(start)}" end="${formatUTCDate(end)}" />
+        </c:calendar-data>
+      </d:prop>
+      ${hrefElements}
+    </c:calendar-multiget>`;
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -3,4 +3,5 @@
  */
 
 export { CalendarService } from './calendar/calendar-service.js';
+export { EventService } from './calendar/event-service.js';
 export { createLogger, Logger, LogLevel } from './logger.js';


### PR DESCRIPTION
## Summary
- Implement full CRUD operations for Nextcloud calendar events
- Add ADHD-friendly features (priority, energy level, categorization)
- Create iCalendar utilities for parsing and generating iCal data
- Extend HTTP client with event-specific methods
- Add XML utilities for event operations

## Test plan
- Manual testing of all CRUD operations against Nextcloud instance
- Tests for iCalendar parsing and generation
- Tests for XML utilities
- Tests for HTTP client extensions

This PR implements the requirements for issue #5.

🤖 Generated with [Claude Code](https://claude.ai/code)
